### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,13 @@
 name: C/C++ CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/bobrossrtx/virtcomp/security/code-scanning/28](https://github.com/bobrossrtx/virtcomp/security/code-scanning/28)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow only involves reading the repository contents (e.g., for checking out the code), we will set `contents: read`. This ensures that the workflow has the minimal permissions required to function correctly.

The changes will be made at the top level of the workflow file, just below the `name` field, to apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
